### PR TITLE
Update CustomPortalApi

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@ loader_version=0.11.3
 fabric_api_version=0.32.5+1.16
 databreaker_version=0.2.6
 seedy_version=1.0.1
-customportalapi_version=0.0.1-beta26-1.16
+customportalapi_version=0.0.1-beta29-1.16
 trinkets_version=2.6.7

--- a/src/main/java/com/aether/blocks/AetherPortalBlock.java
+++ b/src/main/java/com/aether/blocks/AetherPortalBlock.java
@@ -4,11 +4,14 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.kyrptonaught.customportalapi.CustomPortalBlock;
 import net.minecraft.block.AbstractBlock;
+import net.minecraft.block.Block;
 import net.minecraft.block.BlockState;
+import net.minecraft.block.Blocks;
 import net.minecraft.particle.ParticleTypes;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
 import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
 import net.minecraft.world.World;
 
 import java.util.Random;
@@ -42,5 +45,10 @@ public class AetherPortalBlock extends CustomPortalBlock {
         }
         if (world.getRandom().nextInt(6) != 0) world.addParticle(ParticleTypes.DRIPPING_WATER, d, e, f, g, h, j);
         else world.addParticle(ParticleTypes.CLOUD, d, e, f, 0, 0, 0);
+    }
+
+    @Override
+    public Block getPortalBase(BlockView world, BlockPos pos) {
+        return Blocks.GLOWSTONE;
     }
 }

--- a/src/main/resources/data/the_aether/custom_portal_generation/ip_aether_portal.json
+++ b/src/main/resources/data/the_aether/custom_portal_generation/ip_aether_portal.json
@@ -1,0 +1,6 @@
+{
+  "schema_version": "imm_ptl:v1",
+  "from": ["minecraft:overworld"],"to": "the_aether:the_aether",
+  "form": {"type": "imm_ptl:convert_conventional_portal","portal_block": "the_aether:blue_portal"},
+  "trigger": {"type": "imm_ptl:conventional_dimension_change"}
+}


### PR DESCRIPTION
Updates CustomPortalApi to beta29. This also fixes /setblock on the aether portal, it will now teleport you.(Interestingly it is also recognized as a valid return portal)

#190 and #189 are no longer needed 

Closes #107 and #106 