### PR TITLE
Add Swets

### DIFF
--- a/src/main/java/com/aether/client/rendering/entity/AetherEntityRenderers.java
+++ b/src/main/java/com/aether/client/rendering/entity/AetherEntityRenderers.java
@@ -31,6 +31,8 @@ public class AetherEntityRenderers {
         register(AetherEntityTypes.CHEST_MIMIC, (entityRendererDispatcher, context) -> new ChestMimicRenderer(entityRendererDispatcher));
         //entityRenderMap.put(EntityWhirlwind.class, new WhirlwindRenderer(renderManager));
         //entityRenderMap.put(EntityPhoenixArrow.class, new PhoenixArrowRenderer(renderManager));
+        register(AetherEntityTypes.BLUE_SWET, (entityRenderDispatcher, context) -> new SwetRenderer(entityRenderDispatcher));
+        register(AetherEntityTypes.YELLOW_SWET, (entityRenderDispatcher, context) -> new SwetRenderer(entityRenderDispatcher));
     }
 
     private static void register(EntityType<? extends Entity> clazz, EntityRendererRegistry.Factory factory) {

--- a/src/main/java/com/aether/client/rendering/entity/SwetRenderer.java
+++ b/src/main/java/com/aether/client/rendering/entity/SwetRenderer.java
@@ -1,0 +1,10 @@
+package com.aether.client.rendering.entity;
+
+import net.minecraft.client.render.entity.EntityRenderDispatcher;
+import net.minecraft.client.render.entity.SlimeEntityRenderer;
+
+public class SwetRenderer extends SlimeEntityRenderer {
+    public SwetRenderer(EntityRenderDispatcher entityRenderDispatcher) {
+        super(entityRenderDispatcher);
+    }
+}

--- a/src/main/java/com/aether/entities/AetherEntityTypes.java
+++ b/src/main/java/com/aether/entities/AetherEntityTypes.java
@@ -2,19 +2,13 @@ package com.aether.entities;
 
 import com.aether.Aether;
 import com.aether.blocks.AetherBlocks;
-import com.aether.client.rendering.entity.*;
 import com.aether.entities.block.FloatingBlockEntity;
-import com.aether.entities.hostile.AechorPlantEntity;
-import com.aether.entities.hostile.ChestMimicEntity;
-import com.aether.entities.hostile.CockatriceEntity;
+import com.aether.entities.hostile.*;
 import com.aether.entities.passive.*;
 import com.aether.entities.projectile.EnchantedDartEntity;
 import com.aether.entities.projectile.GoldenDartEntity;
 import com.aether.entities.projectile.PoisonDartEntity;
 import com.aether.entities.projectile.PoisonNeedleEntity;
-import net.fabricmc.api.EnvType;
-import net.fabricmc.api.Environment;
-import net.fabricmc.fabric.api.client.rendereregistry.v1.EntityRendererRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricDefaultAttributeRegistry;
 import net.fabricmc.fabric.api.object.builder.v1.entity.FabricEntityTypeBuilder;
 import net.minecraft.entity.*;
@@ -52,6 +46,8 @@ public class AetherEntityTypes {
 //    public static EntityType<FireMinionEntity> FIRE_MINION;
 //    public static EntityType<CrystalEntity> CRYSTAL;
 //    public static EntityType<PhoenixArrowEntity> PHOENIX_ARROW;
+    public static final EntityType<SwetEntity> BLUE_SWET;
+    public static final EntityType<SwetEntity> YELLOW_SWET;
 
     static {
         AECHOR_PLANT = register("aechor_plant", SpawnGroup.MONSTER, EntityDimensions.changing(1.0F, 1.0F), (entityType, world) -> new AechorPlantEntity(world));
@@ -73,6 +69,8 @@ public class AetherEntityTypes {
 //        FIRE_MINION = register("fire_minion", ...);
 //        CRYSTAL = register("crystal", ...);
 //        PHOENIX_ARROW = register("phoenix_arrow", ...);
+        BLUE_SWET = register("blue_swet", SpawnGroup.MONSTER, EntityDimensions.changing(2.0F, 2.0F), (entityType, world) -> new BlueSwetEntity(world));
+        YELLOW_SWET = register("yellow_swet", SpawnGroup.MONSTER, EntityDimensions.changing(2.0F, 2.0F), (entityType, world) -> new YellowSwetEntity(world));
     }
 
     public static void init() {
@@ -86,6 +84,8 @@ public class AetherEntityTypes {
         FabricDefaultAttributeRegistry.register(COCKATRICE, CockatriceEntity.initAttributes());
         FabricDefaultAttributeRegistry.register(AERWHALE, AerwhaleEntity.initAttributes());
         FabricDefaultAttributeRegistry.register(CHEST_MIMIC, ChestMimicEntity.initAttributes());
+        FabricDefaultAttributeRegistry.register(BLUE_SWET, SwetEntity.initAttributes());
+        FabricDefaultAttributeRegistry.register(YELLOW_SWET, SwetEntity.initAttributes());
 
         SpawnRestriction.register(AERWHALE, SpawnRestriction.Location.NO_RESTRICTIONS, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, AetherEntityTypes::getAnimalData);
         SpawnRestriction.register(SHEEPUFF, SpawnRestriction.Location.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, AetherEntityTypes::getAnimalData);
@@ -94,6 +94,8 @@ public class AetherEntityTypes {
         SpawnRestriction.register(FLYING_COW, SpawnRestriction.Location.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, AetherEntityTypes::getAnimalData);
         SpawnRestriction.register(COCKATRICE, SpawnRestriction.Location.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, AetherEntityTypes::getHostileData);
         SpawnRestriction.register(AECHOR_PLANT, SpawnRestriction.Location.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, AetherEntityTypes::getHostileData);
+        SpawnRestriction.register(BLUE_SWET, SpawnRestriction.Location.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, AetherEntityTypes::getHostileData);
+        SpawnRestriction.register(YELLOW_SWET, SpawnRestriction.Location.ON_GROUND, Heightmap.Type.MOTION_BLOCKING_NO_LEAVES, AetherEntityTypes::getHostileData);
     }
 
     public static DefaultAttributeContainer.Builder getDefaultAttributes() {

--- a/src/main/java/com/aether/entities/hostile/BlueSwetEntity.java
+++ b/src/main/java/com/aether/entities/hostile/BlueSwetEntity.java
@@ -1,0 +1,10 @@
+package com.aether.entities.hostile;
+
+import com.aether.entities.AetherEntityTypes;
+import net.minecraft.world.World;
+
+public class BlueSwetEntity extends SwetEntity{
+    public BlueSwetEntity(World world){
+        super(AetherEntityTypes.BLUE_SWET, world);
+    }
+}

--- a/src/main/java/com/aether/entities/hostile/SwetEntity.java
+++ b/src/main/java/com/aether/entities/hostile/SwetEntity.java
@@ -1,0 +1,75 @@
+package com.aether.entities.hostile;
+
+import com.aether.entities.AetherEntityTypes;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.EntityType;
+import net.minecraft.entity.attribute.DefaultAttributeContainer;
+import net.minecraft.entity.attribute.EntityAttributes;
+import net.minecraft.entity.mob.SlimeEntity;
+import net.minecraft.entity.player.PlayerEntity;
+import net.minecraft.world.World;
+
+public class SwetEntity extends SlimeEntity {
+    public int stuckCooldown = 0;
+
+    public SwetEntity(World world){
+        super(AetherEntityTypes.BLUE_SWET, world);
+        init();
+    }
+
+    public SwetEntity(EntityType<? extends SwetEntity> entityType, World world){
+        super(entityType, world);
+        init();
+    }
+
+    private void init(){
+        super.setSize(2, false);
+        getAttributeInstance(EntityAttributes.GENERIC_MAX_HEALTH).setBaseValue(25);
+        setHealth(getMaxHealth());
+    }
+
+    public static DefaultAttributeContainer.Builder initAttributes() {
+        return AetherEntityTypes.getDefaultAttributes()
+                .add(EntityAttributes.GENERIC_FOLLOW_RANGE, 8.0D)
+                .add(EntityAttributes.GENERIC_MOVEMENT_SPEED, 0.28000000417232513D)
+                .add(EntityAttributes.GENERIC_ATTACK_DAMAGE, 3.0D)
+                .add(EntityAttributes.GENERIC_MAX_HEALTH, 25.0D);
+    }
+
+    @Override
+    public void tick(){
+        if(stuckCooldown >= 0){
+            System.out.println(stuckCooldown);
+            --stuckCooldown;
+        }
+        super.tick();
+    }
+
+    @Override
+    public void onPlayerCollision(PlayerEntity player){
+        if (player.getVehicle() == null && stuckCooldown <= 0) {
+            player.startRiding(this, true);
+        } else {
+            super.onPlayerCollision(player);
+        }
+    }
+
+    protected void removePassenger(Entity passenger) {
+        if (passenger instanceof PlayerEntity) {
+            stuckCooldown = 30;
+        }
+    }
+
+    // Prevents the size from being changed
+    @Override
+    protected void setSize(int size, boolean heal){
+        if (heal) {
+            this.setHealth(this.getMaxHealth());
+        }
+    }
+
+    @Override
+    public void remove(){
+        this.removed = true;
+    }
+}

--- a/src/main/java/com/aether/entities/hostile/YellowSwetEntity.java
+++ b/src/main/java/com/aether/entities/hostile/YellowSwetEntity.java
@@ -1,0 +1,10 @@
+package com.aether.entities.hostile;
+
+import com.aether.entities.AetherEntityTypes;
+import net.minecraft.world.World;
+
+public class YellowSwetEntity extends SwetEntity{
+    public YellowSwetEntity(World world){
+        super(AetherEntityTypes.YELLOW_SWET, world);
+    }
+}

--- a/src/main/resources/data/the_aether/loot_tables/entities/blue_swet.json
+++ b/src/main/resources/data/the_aether/loot_tables/entities/blue_swet.json
@@ -1,0 +1,52 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 1,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:looting_enchant",
+              "count": {
+                "min": 1.0,
+                "max": 1.0
+              }
+            }
+          ],
+          "name": "the_aether:swet_ball"
+        },
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "min": 1.0,
+                "max": 2.0,
+                "type": "minecraft:uniform"
+              }
+            },
+            {
+              "function": "minecraft:looting_enchant",
+              "count": {
+                "min": 1.0,
+                "max": 1.0
+              }
+            }
+          ],
+          "name": "the_aether:blue_aercloud"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/the_aether/loot_tables/entities/yellow_swet.json
+++ b/src/main/resources/data/the_aether/loot_tables/entities/yellow_swet.json
@@ -1,0 +1,24 @@
+{
+  "type": "minecraft:entity",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "functions": [
+            {
+              "function": "minecraft:set_count",
+              "count": {
+                "type": "minecraft:uniform",
+                "min": 1.0,
+                "max": 2.0
+              }
+            }
+          ],
+          "name": "minecraft:glowstone"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/data/the_aether/worldgen/biome/aether_highlands.json
+++ b/src/main/resources/data/the_aether/worldgen/biome/aether_highlands.json
@@ -53,13 +53,13 @@
   "spawners": {
     "monster": [
       {
-        "type": "minecraft:slime",
+        "type": "the_aether:swet",
         "weight": 20,
         "minCount": 1,
-        "maxCount": 1
+        "maxCount": 10
       },
       {
-        "type": "minecraft:endermen",
+        "type": "minecraft:enderman",
         "weight": 2,
         "minCount": 1,
         "maxCount": 1
@@ -92,11 +92,15 @@
   },
   "creature_spawn_probability": 0.4,
   "spawn_costs": {
-    "minecraft:endermen": {
+    "minecraft:enderman": {
       "energy_budget": 0.02,
       "charge": 3.0
     },
     "minecraft:phantom": {
+      "energy_budget": 0.01,
+      "charge": 2.0
+    },
+    "the_aether:swet": {
       "energy_budget": 0.01,
       "charge": 2.0
     }


### PR DESCRIPTION
Added Blue Swets and Yellow Swets.
They do everything that they did in the original aether legacy. This implementation allows for more swet variants in the future if that is ever wanted.
Right now they use the slime models and textures as placeholders until custom models and textures are created.
The swet loot tables don't always work, and will likely need to be changed.