### PR TITLE
Fix server crash

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@
 # suppress inspection "UnusedProperty"
 org.gradle.jvmargs=-Xmx2G
 # Mod Properties
-mod_version=1.16.5-1.0.3
+mod_version=1.16.5-1.0.4
 maven_group=com.aether
 archives_base_name=aether
 # Fabric Properties

--- a/src/main/java/com/aether/util/DynamicBlockColorProvider.java
+++ b/src/main/java/com/aether/util/DynamicBlockColorProvider.java
@@ -4,8 +4,7 @@ import net.fabricmc.api.EnvType;
 import net.fabricmc.api.Environment;
 import net.minecraft.client.color.block.BlockColorProvider;
 
-@Environment(EnvType.CLIENT)
 public interface DynamicBlockColorProvider {
-
+    @Environment(EnvType.CLIENT)
     BlockColorProvider getProvider();
 }


### PR DESCRIPTION
The entire interface `DynamicBlockColorProvider` was annotated as `@Environment(EnvType.CLIENT)`, leading to a server crash if it was classloaded on the server at all. This PR removes that annotation from the interface and puts it on the interface's method instead.


I have also updated the project's version information to reflect the release of 1.0.4.