### PR TITLE
Changes to blueberries

### DIFF
--- a/src/main/java/com/aether/blocks/AetherBlocks.java
+++ b/src/main/java/com/aether/blocks/AetherBlocks.java
@@ -289,7 +289,7 @@ public class AetherBlocks {
         ANGELIC_STAIRS = register("angelic_stairs", new StairsBlock(ANGELIC_STONE.getDefaultState(), AbstractBlock.Settings.copy(ANGELIC_STONE)), buildingBlock());
 //        ANGELIC_STONE_TRAP = register("angelic_stone_trap", new Block(BlockBehaviour.Properties.of(Material.STONE).hardness(-1.0f).resistance(6000000.0f).sounds(BlockSoundGroup.STONE)));
         ANGELIC_WALL = register("angelic_wall", new WallBlock(AbstractBlock.Settings.copy(ANGELIC_STONE)), buildingBlock());
-        BLUEBERRY_BUSH = register("blueberry_bush", new BlueberryBushBlock(AbstractBlock.Settings.of(Material.REPLACEABLE_PLANT).strength(0.2F).ticksRandomly().sounds(BlockSoundGroup.GRASS).nonOpaque().allowsSpawning(AetherBlocks::canSpawnOnLeaves).suffocates(AetherBlocks::never).blockVision(AetherBlocks::never).noCollision()), buildingBlock());
+        BLUEBERRY_BUSH = register("blueberry_bush", new BlueberryBushBlock(AbstractBlock.Settings.of(Material.REPLACEABLE_PLANT).strength(0.2F).ticksRandomly().sounds(BlockSoundGroup.GRASS).nonOpaque().allowsSpawning(AetherBlocks::canSpawnOnLeaves).suffocates(AetherBlocks::never).blockVision(AetherBlocks::never).noCollision()));
 //        BLACK_DYED_AERCLOUD = register("black_dyed_aercloud", null);
 //        BLUE_DYED_AERCLOUD = register("blue_dyed_aercloud", null);
 //        BROWN_DYED_AERCLOUD = register("brown_dyed_aercloud", null);

--- a/src/main/java/com/aether/items/AetherItems.java
+++ b/src/main/java/com/aether/items/AetherItems.java
@@ -152,7 +152,7 @@ public class AetherItems {
 
         // Food
         AetherItemSettings LOOT_FOOD = new AetherItemSettings().group(AetherItemGroups.Food).rarity(AetherItems.AETHER_LOOT);
-        BLUEBERRY = register("blue_berry", new BlockItem(AetherBlocks.BLUEBERRY_BUSH, new Item.Settings().group(AetherItemGroups.Food).food(AetherFood.DEFAULT)));
+        BLUEBERRY = register("blue_berry", new AliasedBlockItem(AetherBlocks.BLUEBERRY_BUSH, new Item.Settings().group(AetherItemGroups.Food).food(AetherFood.DEFAULT)));
         ENCHANTED_BLUEBERRY = register("enchanted_blueberry", new Item(new Item.Settings().group(AetherItemGroups.Food).rarity(Rarity.RARE).food(AetherFood.ENCHANTED_BLUEBERRY)));
         WHITE_APPLE = register("white_apple", new WhiteApple(new Item.Settings().group(AetherItemGroups.Food).food(AetherFood.WHITE_APPLE)));
         BLUE_GUMMY_SWET = register("blue_gummy_swet", new GummySwet(LOOT_FOOD));

--- a/src/main/resources/assets/the_aether/lang/en_us.json
+++ b/src/main/resources/assets/the_aether/lang/en_us.json
@@ -206,7 +206,7 @@
   "item.the_aether.ambrosium_shard": "Ambrosium Shard",
   "item.the_aether.ascending_dawn": "Valkyrie Music Disc",
   "item.the_aether.black_moa_egg": "Black Moa Egg",
-  "item.the_aether.blue_berry": "Blue Berry",
+  "item.the_aether.blue_berry": "Blueberries",
   "item.the_aether.blue_cape": "Blue Cloak",
   "item.the_aether.blue_gummy_swet": "Blue Gummy Swet",
   "item.the_aether.blue_moa_egg": "Blue Moa Egg",


### PR DESCRIPTION
Bug fix: Blueberries are no longer listed twice in the creative menu, and are in the correct item group. Resolves issue #274.
Bug fix: The Blue Berry item now has a separate name than its block form, as implied by the language files.
Change: The Blue Berry item has had its name changed to Blueberries to better reflect the current texture as well as to match the naming convention of Minecraft's foods, namely the Sweet Berries item.