### PR TITLE
Temporary fix for two-tall blocks

### DIFF
--- a/src/main/java/com/aether/items/tools/IAetherTool.java
+++ b/src/main/java/com/aether/items/tools/IAetherTool.java
@@ -6,6 +6,7 @@ import net.minecraft.block.BlockState;
 import net.minecraft.block.FallingBlock;
 import net.minecraft.item.ItemStack;
 import net.minecraft.item.ItemUsageContext;
+import net.minecraft.state.property.Properties;
 import net.minecraft.util.ActionResult;
 import net.minecraft.util.math.BlockPos;
 import net.minecraft.world.World;
@@ -20,18 +21,28 @@ public interface IAetherTool {
 
     Logger log = LogManager.getLogger(IAetherTool.class);
 
+    private boolean eligibleToFloat(ItemUsageContext context) {
+        BlockPos pos = context.getBlockPos();
+        World world = context.getWorld();
+        BlockState state = world.getBlockState(pos);
+        ItemStack heldItem = context.getStack();
+        return (!state.isToolRequired() || heldItem.isSuitableFor(state))
+                && FallingBlock.canFallThrough(world.getBlockState(pos.up()))
+                && !state.getProperties().contains(Properties.DOUBLE_BLOCK_HALF);
+    }
+
     default ActionResult useOnBlock(ItemUsageContext context, @Nullable ActionResult defaultResult) {
         if (this.getTier() == AetherTiers.Gravitite) {
             BlockPos pos = context.getBlockPos();
             World world = context.getWorld();
             BlockState state = world.getBlockState(pos);
-            ItemStack heldItem = context.getStack();
 
-            if ((!state.isToolRequired() || heldItem.isSuitableFor(state)) && FallingBlock.canFallThrough(world.getBlockState(pos.up()))) {
+            if (eligibleToFloat(context)) {
                 if (world.getBlockEntity(pos) != null || state.getHardness(world, pos) == -1.0F) {
                     return ActionResult.FAIL;
                 }
 
+                // TODO: Add compatibility for two-tall blocks such as doors and tall grass
                 if (!world.isClient()) {
                     FloatingBlockEntity entity = new FloatingBlockEntity(world, pos.getX() + 0.5, pos.getY(), pos.getZ() + 0.5, state);
                     entity.floatTime = 0;


### PR DESCRIPTION
Fixes issues related to two-tall blocks becoming FloatingBlockEntities.
Temporarily prevents two-tall blocks such as doors and tall grass from becoming FloatingBlockEntities until the feature is implemented.