### PR TITLE
Fix duplication glitch

### DIFF
--- a/src/main/java/com/aether/entities/block/FloatingBlockStructure.java
+++ b/src/main/java/com/aether/entities/block/FloatingBlockStructure.java
@@ -24,6 +24,9 @@ public class FloatingBlockStructure {
     public void spawn(World world){
         blockInfos.forEach(blockInfo -> {
             blockInfo.block.markPartOfStructure();
+            if(!blockInfo.equals(blockInfos.get(0))){
+                blockInfo.block.dropItem = false;
+            }
             blockInfo.block.floatTime = 0;
             world.spawnEntity(blockInfo.block);
         });


### PR DESCRIPTION
Tall blocks would drop themselves twice instead of once if they couldn't land. Now they drop themselves once.