### PR TITLE
[DRAFT] Quicksoil rails

### DIFF
--- a/src/main/java/com/aether/blocks/AetherBlocks.java
+++ b/src/main/java/com/aether/blocks/AetherBlocks.java
@@ -9,6 +9,7 @@ import com.aether.blocks.decorative.AmbrosiumTorchBlock;
 import com.aether.blocks.decorative.AmbrosiumTorchWallBlock;
 import com.aether.blocks.mechanical.FoodBowlBlock;
 import com.aether.blocks.natural.*;
+import com.aether.blocks.rail.QuickoilRailBlock;
 import com.aether.client.rendering.block.FluidRenderSetup;
 import com.aether.entities.AetherEntityTypes;
 import com.aether.entities.util.RenderUtils;
@@ -152,7 +153,8 @@ public class AetherBlocks {
     public static final Block QUICKSOIL;
     public static final Block QUICKSOIL_GLASS;
     public static final Block QUICKSOIL_GLASS_PANE;
-//    public static final Block RED_DYED_AERCLOUD;
+    public static final Block QUICKSOIL_RAIL;
+    //    public static final Block RED_DYED_AERCLOUD;
     public static final Block SENTRY_SLAB;
     public static final Block SENTRY_STAIRS;
     public static final Block SENTRY_STONE;
@@ -332,6 +334,7 @@ public class AetherBlocks {
         final Settings ANGELIC_STONES = Settings.of(Material.STONE).hardness(0.5f).resistance(1.0f).sounds(BlockSoundGroup.STONE);
         ANGELIC_STONE = register("angelic_stone", new Block(ANGELIC_STONES), buildingBlock());
         ANGELIC_CRACKED_STONE = register("angelic_stone_cracked", new Block(ANGELIC_STONES), buildingBlock());
+
         ANGELIC_SLAB = register("angelic_slab", new SlabBlock(Settings.copy(ANGELIC_STONE)), buildingBlock());
         ANGELIC_STAIRS = register("angelic_stairs", new StairsBlock(ANGELIC_STONE.getDefaultState(), Settings.copy(ANGELIC_STONE)), buildingBlock());
 //        ANGELIC_STONE_TRAP = register("angelic_stone_trap", new Block(BlockBehaviour.Properties.of(Material.STONE).hardness(-1.0f).resistance(6000000.0f).sounds(BlockSoundGroup.STONE)));
@@ -427,6 +430,7 @@ public class AetherBlocks {
         QUICKSOIL = register("quicksoil", new Block(Settings.of(Material.AGGREGATE).strength(0.5f, -1.0f).slipperiness(1.0F).velocityMultiplier(1.102F).sounds(BlockSoundGroup.SAND)), buildingBlock());
         QUICKSOIL_GLASS = register("quicksoil_glass", new GlassBlock(Settings.of(Material.GLASS).luminance(state -> 14).strength(0.2f, -1.0f).slipperiness(1.0F).velocityMultiplier(1.102F).sounds(BlockSoundGroup.GLASS).nonOpaque().solidBlock(AetherBlocks::never)), buildingBlock());
         QUICKSOIL_GLASS_PANE = register("quicksoil_glass_pane", new PaneBlock(Settings.of(Material.GLASS).luminance(state -> 14).strength(0.2F, -1.0F).slipperiness(1.0F).velocityMultiplier(1.102F).sounds(BlockSoundGroup.GLASS).nonOpaque().solidBlock(AetherBlocks::never)), buildingBlock());
+        QUICKSOIL_RAIL = register("quicksoil_rail", new QuickoilRailBlock(Settings.of(Material.DECORATION).noCollision().strength(0.7F).slipperiness(1.0F).velocityMultiplier(1.102F).sounds(BlockSoundGroup.GLASS)), buildingBlock());
 //        RED_DYED_AERCLOUD = register("red_dyed_aercloud", null);
         FLUTEGRASS = register("flutegrass", new AetherBrushBlock(GRASS.mapColor(MapColor.GOLD), ImmutableSet.of(QUICKSOIL), true), buildingBlock());
         final Settings SENTRY_STONES = Settings.of(Material.STONE).hardness(0.5f).resistance(1.0f).sounds(BlockSoundGroup.STONE);

--- a/src/main/java/com/aether/blocks/rail/QuickoilRailBlock.java
+++ b/src/main/java/com/aether/blocks/rail/QuickoilRailBlock.java
@@ -1,0 +1,12 @@
+package com.aether.blocks.rail;
+
+import net.minecraft.block.AbstractRailBlock;
+import net.minecraft.block.RailBlock;
+import net.minecraft.block.enums.RailShape;
+import net.minecraft.state.property.Property;
+
+public class QuickoilRailBlock extends RailBlock {
+    public QuickoilRailBlock(Settings settings) {
+        super(settings);
+    }
+}

--- a/src/main/java/com/aether/entities/AetherMinecartExtensions.java
+++ b/src/main/java/com/aether/entities/AetherMinecartExtensions.java
@@ -1,0 +1,7 @@
+package com.aether.entities;
+
+public interface AetherMinecartExtensions {
+    double getBoostSpeed();
+
+    void setBoostSpeed(double boostSpeed);
+}

--- a/src/main/java/com/aether/mixin/entity/AbstractMinecartEntityMixin.java
+++ b/src/main/java/com/aether/mixin/entity/AbstractMinecartEntityMixin.java
@@ -1,0 +1,70 @@
+package com.aether.mixin.entity;
+
+import com.aether.blocks.AetherBlocks;
+import com.aether.entities.AetherMinecartExtensions;
+import net.minecraft.block.BlockState;
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.vehicle.AbstractMinecartEntity;
+import net.minecraft.nbt.NbtCompound;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.GameRules;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(AbstractMinecartEntity.class)
+public abstract class AbstractMinecartEntityMixin implements AetherMinecartExtensions {
+    private double boostSpeed = 1;
+
+    @Shadow
+    public abstract void moveOnRail(BlockPos pos, BlockState state);
+
+    @Override
+    public double getBoostSpeed() {
+        return boostSpeed;
+    }
+
+    @Override
+    public void setBoostSpeed(double boostSpeed) {
+        this.boostSpeed = boostSpeed;
+    }
+
+    @Inject(method = "getMaxOffRailSpeed", at = @At("TAIL"), cancellable = true)
+    private void getMaxOffRailSpeed(CallbackInfoReturnable<Double> ci) {
+        ci.setReturnValue(ci.getReturnValueD() *  this.getBoostSpeed());
+    }
+
+    @Inject(method = "moveOnRail", at = @At("HEAD"))
+    private void moveOnRail(BlockPos pos, BlockState state, CallbackInfo ci) {
+        if (state.isOf(AetherBlocks.QUICKSOIL_RAIL)) {
+            if (((Entity) (Object) this).world.getGameRules().getBoolean(GameRules.DO_FIRE_TICK)) {
+                this.setBoostSpeed(this.getBoostSpeed() * 1.166);
+                ((Entity) (Object) this).setVelocity(((Entity) (Object) this).getVelocity().multiply(1.05, 1, 1.05));
+            } else {
+                this.setBoostSpeed(4);
+            }
+        }
+    }
+
+    @Inject(method = "tick", at = @At("HEAD"))
+    private void tick(CallbackInfo ci) {
+        if (((Entity) (Object) this).world.getGameRules().getBoolean(GameRules.DO_FIRE_TICK)) {
+            this.setBoostSpeed(Math.max(this.getBoostSpeed() * 0.9, 1));
+        } else {
+            this.setBoostSpeed(1);
+        }
+    }
+
+    @Inject(method = "readCustomDataFromNbt", at = @At("HEAD"))
+    private void readCustomDataFromNbt(NbtCompound nbt, CallbackInfo ci) {
+        this.setBoostSpeed(nbt.getDouble("BoostSpeed"));
+    }
+
+    @Inject(method = "writeCustomDataToNbt", at = @At("HEAD"))
+    private void writeCustomDataToNbt(NbtCompound nbt, CallbackInfo ci) {
+        nbt.putDouble("BoostSpeed", this.getBoostSpeed());
+    }
+}

--- a/src/main/resources/assets/the_aether/blockstates/quicksoil_rail.json
+++ b/src/main/resources/assets/the_aether/blockstates/quicksoil_rail.json
@@ -1,0 +1,40 @@
+{
+  "variants": {
+    "shape=ascending_east": {
+      "model": "the_aether:block/quicksoil_rail_raised_ne",
+      "y": 90
+    },
+    "shape=ascending_north": {
+      "model": "the_aether:block/quicksoil_rail_raised_ne"
+    },
+    "shape=ascending_south": {
+      "model": "the_aether:block/quicksoil_rail_raised_sw"
+    },
+    "shape=ascending_west": {
+      "model": "the_aether:block/quicksoil_rail_raised_sw",
+      "y": 90
+    },
+    "shape=east_west": {
+      "model": "the_aether:block/quicksoil_rail",
+      "y": 90
+    },
+    "shape=north_east": {
+      "model": "the_aether:block/quicksoil_rail_corner",
+      "y": 270
+    },
+    "shape=north_south": {
+      "model": "the_aether:block/quicksoil_rail"
+    },
+    "shape=north_west": {
+      "model": "the_aether:block/quicksoil_rail_corner",
+      "y": 180
+    },
+    "shape=south_east": {
+      "model": "the_aether:block/quicksoil_rail_corner"
+    },
+    "shape=south_west": {
+      "model": "the_aether:block/quicksoil_rail_corner",
+      "y": 90
+    }
+  }
+}

--- a/src/main/resources/assets/the_aether/models/block/quicksoil_rail.json
+++ b/src/main/resources/assets/the_aether/models/block/quicksoil_rail.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/rail_flat",
+  "textures": {
+    "rail": "minecraft:block/rail"
+  }
+}

--- a/src/main/resources/assets/the_aether/models/block/quicksoil_rail_corner.json
+++ b/src/main/resources/assets/the_aether/models/block/quicksoil_rail_corner.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/rail_curved",
+  "textures": {
+    "rail": "minecraft:block/rail_corner"
+  }
+}

--- a/src/main/resources/assets/the_aether/models/block/quicksoil_rail_curved.json
+++ b/src/main/resources/assets/the_aether/models/block/quicksoil_rail_curved.json
@@ -1,0 +1,15 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "#rail"
+    },
+    "elements": [
+        {   "from": [ 0, 1, 0 ],
+            "to": [ 16, 1, 16 ],
+            "faces": {
+                "down":  { "uv": [ 0, 16, 16,  0 ], "texture": "#rail" },
+                "up":    { "uv": [ 0,  0, 16, 16 ], "texture": "#rail" }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/the_aether/models/block/quicksoil_rail_flat.json
+++ b/src/main/resources/assets/the_aether/models/block/quicksoil_rail_flat.json
@@ -1,0 +1,15 @@
+{
+    "ambientocclusion": false,
+    "textures": {
+        "particle": "#rail"
+    },
+    "elements": [
+        {   "from": [ 0, 1, 0 ],
+            "to": [ 16, 1, 16 ],
+            "faces": {
+                "down":  { "uv": [ 0, 16, 16,  0 ], "texture": "#rail" },
+                "up":    { "uv": [ 0,  0, 16, 16 ], "texture": "#rail" }
+            }
+        }
+    ]
+}

--- a/src/main/resources/assets/the_aether/models/block/quicksoil_rail_raised_ne.json
+++ b/src/main/resources/assets/the_aether/models/block/quicksoil_rail_raised_ne.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/template_rail_raised_ne",
+  "textures": {
+    "rail": "minecraft:block/rail"
+  }
+}

--- a/src/main/resources/assets/the_aether/models/block/quicksoil_rail_raised_sw.json
+++ b/src/main/resources/assets/the_aether/models/block/quicksoil_rail_raised_sw.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:block/template_rail_raised_sw",
+  "textures": {
+    "rail": "minecraft:block/rail"
+  }
+}

--- a/src/main/resources/assets/the_aether/models/item/quicksoil_rail.json
+++ b/src/main/resources/assets/the_aether/models/item/quicksoil_rail.json
@@ -1,0 +1,6 @@
+{
+  "parent": "minecraft:item/generated",
+  "textures": {
+    "layer0": "minecraft:block/rail"
+  }
+}

--- a/src/main/resources/data/minecraft/tags/blocks/rails.json
+++ b/src/main/resources/data/minecraft/tags/blocks/rails.json
@@ -1,0 +1,6 @@
+{
+  "replace": false,
+  "values": [
+    "the_aether:quicksoil_rail"
+  ]
+}

--- a/src/main/resources/data/the_aether/loot_tables/blocks/quicksoil_rail.json
+++ b/src/main/resources/data/the_aether/loot_tables/blocks/quicksoil_rail.json
@@ -1,0 +1,20 @@
+{
+  "type": "minecraft:block",
+  "pools": [
+    {
+      "rolls": 1.0,
+      "bonus_rolls": 0.0,
+      "entries": [
+        {
+          "type": "minecraft:item",
+          "name": "the_aether:quicksoil_rail"
+        }
+      ],
+      "conditions": [
+        {
+          "condition": "minecraft:survives_explosion"
+        }
+      ]
+    }
+  ]
+}

--- a/src/main/resources/the_aether.mixins.json
+++ b/src/main/resources/the_aether.mixins.json
@@ -9,6 +9,7 @@
     "block.CropBlockMixin",
     "block.FarmlandBlockMixin",
     "block.PlantBlockMixin",
+    "entity.AbstractMinecartEntityMixin",
     "entity.CowEntityMixin",
     "entity.MixinAbstractFurnaceBlockEntity",
     "entity.MixinLivingEntity",


### PR DESCRIPTION
This branch adds a new block, the quicksoil rail. I've implemented examples of two possible fuctionalities for it, toggleable with the doFireTick gamerule. With fire tick on, they behave similarly to quicksoil, accelerating the cart forever. With fire tick off, they simply allow carts to travel at 4* the regular speed whilst on them. Both functionalities are implemented in such a way as to cleanly avoid conflicts with other minecart-changing mods. I need feedback on where to go with them from here. A attached are compiled jars of the branch as of commit 6602e56.
[aether-quicksoil-rails.tar.gz](https://github.com/devs-immortal/The-Aether/files/6854990/aether-quicksoil-rails.tar.gz)
