### PR TITLE
clean up gradle files and make them more readable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-    id "fabric-loom" version "0.11-SNAPSHOT"
+    id "fabric-loom" version "0.12-SNAPSHOT"
     id "maven-publish"
     id "com.modrinth.minotaur" version "2.+"
     id "de.guntram.mcmod.crowdin-translate" version "1.4+1.18.2"
@@ -13,7 +13,7 @@ crowdintranslate.verbose = true
 JavaLanguageVersion targetVersion = JavaLanguageVersion.of(17)
 
 allprojects {
-    // Allow more then 100 errors to be displayed.
+    // allow more then 100 errors to be displayed
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
             options.compilerArgs << "-Xmaxerrs" << "${project.max_errors}"
@@ -26,14 +26,6 @@ version = project.mod_version
 group = project.maven_group
 
 repositories {
-    maven {
-        name = "guntram"
-        url = "https://minecraft.guntram.de/maven/"
-    }
-    maven {
-        name = "modmenu-legacy"
-        url = "https://maven.fabricmc.net/io/github/prospector/modmenu/"
-    }
     maven {
         name = "fabric"
         url = "https://maven.fabricmc.net/"

--- a/build.gradle
+++ b/build.gradle
@@ -1,27 +1,13 @@
-buildscript {
-    dependencies {
-        classpath "com.github.CDAGaming.CrowdinTranslate:crowdin-translate:${project.crowdin_translate_version}"
-    }
-    repositories {
-        maven {
-            name = 'CrowdinTranslate source'
-            url = "https://minecraft.guntram.de/maven/"
-        }
-        maven {
-            url = "https://jitpack.io"
-        }
-    }
-}
-
 plugins {
-    id 'fabric-loom' version '0.11-SNAPSHOT'
-    id 'maven-publish'
-    id "com.modrinth.minotaur" version "1.2.1"
+    id "fabric-loom" version "0.11-SNAPSHOT"
+    id "maven-publish"
+    id "com.modrinth.minotaur" version "2.+"
+    id "de.guntram.mcmod.crowdin-translate" version "1.4+1.18.2"
 }
 
-apply plugin: 'de.guntram.mcmod.crowdin-translate'
-crowdintranslate.crowdinProjectName = 'aether'
-crowdintranslate.minecraftProjectName = 'the_aether'
+// configure crowdin
+crowdintranslate.crowdinProjectName = "aether"
+crowdintranslate.minecraftProjectName = "the_aether"
 crowdintranslate.verbose = true
 
 JavaLanguageVersion targetVersion = JavaLanguageVersion.of(17)
@@ -41,85 +27,100 @@ group = project.maven_group
 
 repositories {
     maven {
+        name = "guntram"
         url = "https://minecraft.guntram.de/maven/"
     }
     maven {
-        name = "Modmenu-Legacy"
+        name = "modmenu-legacy"
         url = "https://maven.fabricmc.net/io/github/prospector/modmenu/"
     }
     maven {
-        name = "Fabric"
+        name = "fabric"
         url = "https://maven.fabricmc.net/"
     }
-    maven { url = "https://hephaestus.dev/release" }
     maven {
-        name = "TerraformersMC"
+        name = "haven-king"
+        url = "https://hephaestus.dev/release"
+    }
+    maven {
+        name = "terraformers"
         url = "https://maven.terraformersmc.com/releases/"
     }
     maven {
-        name = "Ladysnake Libs"
+        name = "ladysnake"
         url = "https://ladysnake.jfrog.io/artifactory/mods"
     }
     maven {
+        name = "shedaniel"
         url = "https://maven.shedaniel.me/"
     }
     maven {
+        name = "kryptonaught"
         url = "https://maven.kyrptonaught.dev/"
     }
     maven {
+        name = "jitpack"
         url = "https://jitpack.io"
     }
-    maven { url "https://maven.jamieswhiteshirt.com/libs-release/" }
-    mavenCentral()
     maven {
-        name = "gudenau's maven"
+        name = "jamieswhiteshirt"
+        url "https://maven.jamieswhiteshirt.com/libs-release/"
+    }
+    maven {
+        name = "gudenau"
         url = "https://maven.gudenau.net"
         content {
-            includeGroup 'net.gudenau.minecraft'
+            includeGroup "net.gudenau.minecraft"
         }
     }
+    mavenCentral()
 }
 
+// set location of access widener
 loom {
     accessWidenerPath = file("src/main/resources/the_aether.accesswidener")
 }
 
 dependencies {
-    // To change the versions see the gradle.properties file
+    // to update dependency versions go to gradle.properties
+
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.mappings_version}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-    // Libraries
+    // libraries
+
+    // reach entity attributes: additional entity attributes for reach distance and attack range
     modImplementation(include("com.jamieswhiteshirt:reach-entity-attributes:${project.entity_attributes_version}"))
 
+    // crowdin: translations
     modImplementation(include("com.github.CDAGaming.CrowdinTranslate:crowdin-translate:${project.crowdin_translate_version}"))
 
+    // cardinal components, entity and base
     modImplementation(include("dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cardinal_version}"))
-
     modImplementation(include("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cardinal_version}"))
 
-    // Most important of the libraries :smug:
+    // incubus core: definitely the most important of libraries :unsmug:
     modImplementation(include("com.github.devs-immortal:Incubus-Core:${project.incubus_version}"))
 
-    // Implement the required portions of FAPI
-    // Remember to maintain these, and add the modular bits as needed. 
-    modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}"
+    // simply use full fabric api
+    modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}")
 
-    // Testing only, do not JiJ
-    modImplementation "com.terraformersmc:modmenu:${project.modmenu_version}"
-    modImplementation "me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}"
+    // modmenu and rei: testing only, do not JiJ
+    modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}")
+    modImplementation("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}")
 
-    // Custom Portal Api
+    // custom portal api: massively simplifies setting up a portal
     modImplementation(include("net.kyrptonaught:customportalapi:${project.customportalapi_version}"))
 
-    // Implement Trinkets for parachutes, rings etc.
+    // trinkets: used for parachutes, rings etc.
     modImplementation(include("dev.emi:trinkets:${project.trinkets_version}"))
 
+    // more tags: used for increased compatibility
     modImplementation(include("net.gudenau.minecraft:MoreTags:${project.moretags_version}"))
     modImplementation(include("net.gudenau.minecraft:RecipeConfidence:${project.recipeconfidence_version}"))
 
-    // Required for the funny rainbow tree leaves
+    // satin: required for the funny rainbow tree leaves
     modImplementation(include("io.github.ladysnake:satin:${project.satin_version}"))
 }
 
@@ -127,53 +128,57 @@ processResources {
     inputs.property "version", project.version
 
     filesMatching("fabric.mod.json") {
-        expand 'version': project.version
+        expand "version": project.version
     }
 }
 
+// set java version
 java {
     toolchain {
         languageVersion = targetVersion
     }
 }
 
+// ensure that the encoding is set to UTF-8, no matter what the system default is
+// this fixes some edge cases with special characters not displaying correctly
+// see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
+// if Javadoc is generated, this must be specified in that task too
 tasks.withType(JavaCompile).configureEach {
-    // ensure that the encoding is set to UTF-8, no matter what the system default is
-    // this fixes some edge cases with special characters not displaying correctly
-    // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-    // If Javadoc is generated, this must be specified in that task too.
-    it.options.encoding = 'UTF-8'
+    it.options.encoding = "UTF-8"
 }
 
-// Loom will automatically attach sourcesJar to a RemapSourcesJar task and to the "build" task
-// if it is present.
-// If you remove this task, sources will not be generated.
+// if you remove this task, sources will not be generated
 java {
     withSourcesJar()
 }
 
-//task publishModrinth (type: TaskModrinthUpload){
-//    BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
-//    System.out.println("Enter the modrinth auth token: ");
-//    token = br.readLine(); // Get password
-//    projectId = 'IKpsG0nF'
-//    System.out.println("Enter the version number:");
-//    versionNumber = br.readLine();
-//    System.out.println("Enter the version name:");
-//    versionName = br.readLine();
-//    uploadFile = jar // This is the java jar task
-//    System.out.println("Enter the game version number: (See minotaur docs for valids)");
-//    addGameVersion(br.readLine());
-//    System.out.println("Enter changelog:");
-//    changelog = br.readLine();
-//    addLoader('fabric')
+// task for publishing to modrinth
+//modrinth {
+//    BufferedReader br = new BufferedReader(new InputStreamReader(System.in))
+//    System.out.println("Enter the modrinth auth token: ")
+//    token = br.readLine()
+//    System.out.println("Enter the version name: (version number: " + project.mod_version + ")")
+//    versionName = br.readLine()
+//    System.out.println("Enter changelog:")
+//    changelog = br.readLine()
+//
+//    // game versions are automatically read by minotaur, do not set
+//    versionNumber = project.mod_version // get project version from gradle.properties
+//    projectId = "IKpsG0nF" // set project id
+//    versionType = "beta" // set version type to beta - change this on full release
+//    uploadFile = remapJar // generate jar to be uploaded
+//    loaders = ["fabric"] // set loader to fabric
+//
+//    dependencies {
+//        required.project "P7dR8mSH" // creates a dependency on fabric api
+//    }
 //}
 
 jar {
     manifest {
-        attributes 'Implementation-Title': 'ParadiseLost',
-                'Implementation-Version': project.version,
-                'Main-Class': 'com.aether.executable.InstallerGUI'
+        attributes "Implementation-Title": "ParadiseLost",
+                "Implementation-Version": project.version,
+                "Main-Class": "com.aether.executable.InstallerGUI"
     }
     from "LICENSE.md"
 }
@@ -186,13 +191,14 @@ publishing {
         }
     }
 
-    // select the repositories you want to publish to
+    // repositories to publish to
     repositories {
         // uncomment to publish to the local maven
         // mavenLocal()
     }
 }
 
+// ensure crowdin translations are downloaded
 build {
     dependsOn downloadTranslations
 }

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
     id "de.guntram.mcmod.crowdin-translate" version "1.4+1.18.2"
 }
 
-// configure crowdin
+// Configure Crowdin
 crowdintranslate.crowdinProjectName = "aether"
 crowdintranslate.minecraftProjectName = "the_aether"
 crowdintranslate.verbose = true
@@ -13,7 +13,7 @@ crowdintranslate.verbose = true
 JavaLanguageVersion targetVersion = JavaLanguageVersion.of(17)
 
 allprojects {
-    // allow more then 100 errors to be displayed
+    // Allow more then 100 errors to be displayed
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
             options.compilerArgs << "-Xmaxerrs" << "${project.max_errors}"
@@ -27,39 +27,39 @@ group = project.maven_group
 
 repositories {
     maven {
-        name = "fabric"
+        name = "Fabric"
         url = "https://maven.fabricmc.net/"
     }
     maven {
-        name = "haven-king"
+        name = "Haven-King"
         url = "https://hephaestus.dev/release"
     }
     maven {
-        name = "terraformers"
+        name = "Terraformers"
         url = "https://maven.terraformersmc.com/releases/"
     }
     maven {
-        name = "ladysnake"
+        name = "Ladysnake"
         url = "https://ladysnake.jfrog.io/artifactory/mods"
     }
     maven {
-        name = "shedaniel"
+        name = "Shedaniel"
         url = "https://maven.shedaniel.me/"
     }
     maven {
-        name = "kryptonaught"
+        name = "Kryptonaught"
         url = "https://maven.kyrptonaught.dev/"
     }
     maven {
-        name = "jitpack"
+        name = "Jitpack"
         url = "https://jitpack.io"
     }
     maven {
-        name = "jamieswhiteshirt"
+        name = "Jamieswhiteshirt"
         url "https://maven.jamieswhiteshirt.com/libs-release/"
     }
     maven {
-        name = "gudenau"
+        name = "Gudenau"
         url = "https://maven.gudenau.net"
         content {
             includeGroup "net.gudenau.minecraft"
@@ -68,51 +68,51 @@ repositories {
     mavenCentral()
 }
 
-// set location of access widener
+// Set location of access widener
 loom {
     accessWidenerPath = file("src/main/resources/the_aether.accesswidener")
 }
 
 dependencies {
-    // to update dependency versions go to gradle.properties
+    // To update dependency versions go to gradle.properties
 
     minecraft "com.mojang:minecraft:${project.minecraft_version}"
     mappings "net.fabricmc:yarn:${project.mappings_version}:v2"
     modImplementation "net.fabricmc:fabric-loader:${project.loader_version}"
 
-    // libraries
+    // Libraries
 
-    // reach entity attributes: additional entity attributes for reach distance and attack range
+    // Reach Entity Attributes: additional entity attributes for reach distance and attack range
     modImplementation(include("com.jamieswhiteshirt:reach-entity-attributes:${project.entity_attributes_version}"))
 
-    // crowdin: translations
+    // Crowdin: translations
     modImplementation(include("com.github.CDAGaming.CrowdinTranslate:crowdin-translate:${project.crowdin_translate_version}"))
 
-    // cardinal components, entity and base
+    // Cardinal Components, entity and base
     modImplementation(include("dev.onyxstudios.cardinal-components-api:cardinal-components-base:${project.cardinal_version}"))
     modImplementation(include("dev.onyxstudios.cardinal-components-api:cardinal-components-entity:${project.cardinal_version}"))
 
-    // incubus core: definitely the most important of libraries :unsmug:
+    // Incubus Core: definitely the most important of libraries :unsmug:
     modImplementation(include("com.github.devs-immortal:Incubus-Core:${project.incubus_version}"))
 
-    // simply use full fabric api
+    // Simply use full fabric api
     modImplementation("net.fabricmc.fabric-api:fabric-api:${project.fabric_api_version}")
 
-    // modmenu and rei: testing only, do not JiJ
+    // Modmenu and REI: testing only, do not JiJ
     modImplementation("com.terraformersmc:modmenu:${project.modmenu_version}")
     modImplementation("me.shedaniel:RoughlyEnoughItems-fabric:${project.rei_version}")
 
-    // custom portal api: massively simplifies setting up a portal
+    // Custom Portal Api: massively simplifies setting up a portal
     modImplementation(include("net.kyrptonaught:customportalapi:${project.customportalapi_version}"))
 
-    // trinkets: used for parachutes, rings etc.
+    // Trinkets: used for parachutes, rings etc.
     modImplementation(include("dev.emi:trinkets:${project.trinkets_version}"))
 
-    // more tags: used for increased compatibility
+    // More Tags: used for increased compatibility
     modImplementation(include("net.gudenau.minecraft:MoreTags:${project.moretags_version}"))
     modImplementation(include("net.gudenau.minecraft:RecipeConfidence:${project.recipeconfidence_version}"))
 
-    // satin: required for the funny rainbow tree leaves
+    // Satin: required for the funny rainbow tree leaves
     modImplementation(include("io.github.ladysnake:satin:${project.satin_version}"))
 }
 
@@ -124,27 +124,27 @@ processResources {
     }
 }
 
-// set java version
+// Set java version
 java {
     toolchain {
         languageVersion = targetVersion
     }
 }
 
-// ensure that the encoding is set to UTF-8, no matter what the system default is
-// this fixes some edge cases with special characters not displaying correctly
+// Ensure that the encoding is set to UTF-8, no matter what the system default is
+// This fixes some edge cases with special characters not displaying correctly,
 // see http://yodaconditions.net/blog/fix-for-java-file-encoding-problems-with-gradle.html
-// if Javadoc is generated, this must be specified in that task too
+// If Javadoc is generated, this must be specified in that task too
 tasks.withType(JavaCompile).configureEach {
     it.options.encoding = "UTF-8"
 }
 
-// if you remove this task, sources will not be generated
+// If you remove this task, sources will not be generated
 java {
     withSourcesJar()
 }
 
-// task for publishing to modrinth
+// Task for publishing to modrinth
 //modrinth {
 //    BufferedReader br = new BufferedReader(new InputStreamReader(System.in))
 //    System.out.println("Enter the modrinth auth token: ")
@@ -154,15 +154,15 @@ java {
 //    System.out.println("Enter changelog:")
 //    changelog = br.readLine()
 //
-//    // game versions are automatically read by minotaur, do not set
-//    versionNumber = project.mod_version // get project version from gradle.properties
-//    projectId = "IKpsG0nF" // set project id
-//    versionType = "beta" // set version type to beta - change this on full release
-//    uploadFile = remapJar // generate jar to be uploaded
-//    loaders = ["fabric"] // set loader to fabric
+//    // Game versions are automatically read by minotaur, do not set
+//    versionNumber = project.mod_version // Get project version from gradle.properties
+//    projectId = "IKpsG0nF" // Set project id
+//    versionType = "beta" // Set version type to beta - change this on full release
+//    uploadFile = remapJar // Generate jar to be uploaded
+//    loaders = ["fabric"] // Set loader to fabric
 //
 //    dependencies {
-//        required.project "P7dR8mSH" // creates a dependency on fabric api
+//        required.project "P7dR8mSH" // Creates a dependency on fabric api
 //    }
 //}
 
@@ -175,7 +175,7 @@ jar {
     from "LICENSE.md"
 }
 
-// configure the maven publication
+// Configure the maven publication
 publishing {
     publications {
         mavenJava(MavenPublication) {
@@ -183,14 +183,14 @@ publishing {
         }
     }
 
-    // repositories to publish to
+    // Repositories to publish to
     repositories {
-        // uncomment to publish to the local maven
+        // Uncomment to publish to the local maven
         // mavenLocal()
     }
 }
 
-// ensure crowdin translations are downloaded
+// Ensure Crowdin translations are downloaded
 build {
     dependsOn downloadTranslations
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,20 @@
-# done to increase the memory available to gradle
+# Done to increase the memory available to gradle
 # suppress inspection "UnusedProperty"
 org.gradle.jvmargs=-Xmx2G
 max_errors=400
 
-# mod properties
+# Mod properties
 mod_version=1.6.9+1.18.2
 maven_group=com.aether
 archives_base_name=paradise-lost
 
-# fabric properties
+# Fabric properties
 # check these on https://fabricmc.net/versions.html
 minecraft_version=1.18.2
 mappings_version=1.18.2+build.1
 loader_version=0.13.3
 
-# dependencies
+# Dependencies
 # suppress inspection "UnusedProperty"
 fabric_api_version=0.47.8+1.18.2
 incubus_version=1.18.2-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,20 +1,23 @@
-# Done to increase the memory available to gradle.
+# done to increase the memory available to gradle
 # suppress inspection "UnusedProperty"
 org.gradle.jvmargs=-Xmx2G
 max_errors=400
-# Mod Properties
+
+# mod properties
 mod_version=1.6.9+1.18.2
 maven_group=com.aether
 archives_base_name=paradise-lost
-# Fabric Properties
+
+# fabric properties
 # check these on https://fabricmc.net/versions.html
 minecraft_version=1.18.2
 mappings_version=1.18.2+build.1
 loader_version=0.13.3
-# Dependencies
+
+# dependencies
 # suppress inspection "UnusedProperty"
 fabric_api_version=0.47.8+1.18.2
-incubus_version=1.6.6-1.18.2
+incubus_version=1.18.2-SNAPSHOT
 customportalapi_version=0.0.1-beta50-1.18
 cardinal_version=4.1.3
 trinkets_version=3.3.0

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,12 +1,17 @@
 pluginManagement {
     repositories {
-        jcenter()
         maven {
-            name = 'Fabric'
-            url = 'https://maven.fabricmc.net/'
+            name = "fabric"
+            url = "https://maven.fabricmc.net/"
+        }
+        maven {
+            name = "crowdin source"
+            url = "https://minecraft.guntram.de/maven/"
+        }
+        maven {
+            url = "https://jitpack.io"
         }
         gradlePluginPortal()
         mavenCentral()
-        maven { url 'https://plugins.gradle.org/m2/' }
     }
 }

--- a/settings.gradle
+++ b/settings.gradle
@@ -9,6 +9,7 @@ pluginManagement {
             url = "https://minecraft.guntram.de/maven/"
         }
         maven {
+            name = "jitpack"
             url = "https://jitpack.io"
         }
         gradlePluginPortal()

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,15 +1,15 @@
 pluginManagement {
     repositories {
         maven {
-            name = "fabric"
+            name = "Fabric"
             url = "https://maven.fabricmc.net/"
         }
         maven {
-            name = "crowdin source"
+            name = "Crowdin source"
             url = "https://minecraft.guntram.de/maven/"
         }
         maven {
-            name = "jitpack"
+            name = "Jitpack"
             url = "https://jitpack.io"
         }
         gradlePluginPortal()


### PR DESCRIPTION
major changes:
- update incubus core to fix build
- update minotaur to 2.0 and change task accordingly
- remove CDAgaming's crowdin translate plugin
- clean up mavens and apply a name to each
- clean up old plugin declaration for guntram's crowdin translate in favor of the new, cleaner style
- explain dependencies
- move plugin repositories to settings.gradle
- change all '' to ""
- add more comments
- remove unused maven repositories

closes #671 
closes #681  