### PR TITLE
THE de-moretags-ening

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,6 @@ val crowdinTranslateVersion: String by properties
 val entityAttributesVersion: String by properties
 val modmenuVersion: String by properties
 val reiVersion: String by properties
-val moreTagsVersion: String by properties
 val recipeConfidenceVersion: String by properties
 val satinVersion: String by properties
 
@@ -131,12 +130,6 @@ dependencies {
             group = "com.github.devs-immortal",
             name = "Incubus-Core",
             version = incubusCoreVersion,
-    ).also(::include)
-
-    modImplementation(
-            group = "net.gudenau.minecraft",
-            name = "MoreTags",
-            version = moreTagsVersion,
     ).also(::include)
 
     modImplementation(

--- a/src/main/java/net/id/paradiselost/entities/util/FloatingBlockHelperImpls.java
+++ b/src/main/java/net/id/paradiselost/entities/util/FloatingBlockHelperImpls.java
@@ -1,6 +1,5 @@
 package net.id.paradiselost.entities.util;
 
-import net.gudenau.minecraft.moretags.MoreBlockTags;
 import net.id.paradiselost.api.FloatingBlockHelper;
 import net.id.paradiselost.entities.block.FloatingBlockEntity;
 import net.id.paradiselost.tag.ParadiseLostBlockTags;
@@ -8,6 +7,7 @@ import net.id.incubus_core.blocklikeentities.api.BlockLikeSet;
 import net.minecraft.block.BlockState;
 import net.minecraft.block.Blocks;
 import net.minecraft.block.FallingBlock;
+import net.minecraft.block.PistonBlock;
 import net.minecraft.block.enums.DoubleBlockHalf;
 import net.minecraft.entity.EntityType;
 import net.minecraft.entity.LightningEntity;
@@ -279,7 +279,7 @@ public class FloatingBlockHelperImpls {
                 return false;
             }
             // sides and bottom (sticky blocks)
-            if (state.isIn(MoreBlockTags.STICKY_BLOCKS)) {
+            if (state.isOf(Blocks.SLIME_BLOCK) || state.isOf(Blocks.HONEY_BLOCK)) {
                 // checks each of the sides
                 for (var newPos : new BlockPos[]{
                         pos.north(),
@@ -302,12 +302,12 @@ public class FloatingBlockHelperImpls {
         }
 
         private static boolean isAdjacentBlockStuck(BlockState state, BlockState adjacentState) {
-            if (state.isIn(MoreBlockTags.HONEY_BLOCKS) && adjacentState.isIn(MoreBlockTags.SLIME_BLOCKS)) {
+            if (state.isOf(Blocks.HONEY_BLOCK) && adjacentState.isOf(Blocks.SLIME_BLOCK)) {
                 return false;
-            } else if (state.isIn(MoreBlockTags.SLIME_BLOCKS) && adjacentState.isIn(MoreBlockTags.HONEY_BLOCKS)) {
+            } else if (state.isOf(Blocks.SLIME_BLOCK) && adjacentState.isOf(Blocks.HONEY_BLOCK)) {
                 return false;
             } else {
-                return state.isIn(MoreBlockTags.STICKY_BLOCKS) || adjacentState.isIn(MoreBlockTags.STICKY_BLOCKS);
+                return (state.isOf(Blocks.SLIME_BLOCK) || state.isOf(Blocks.HONEY_BLOCK)) || (adjacentState.isOf(Blocks.SLIME_BLOCK) || adjacentState.isOf(Blocks.HONEY_BLOCK));
             }
         }
     }

--- a/src/main/java/net/id/paradiselost/mixin/block/CropBlockMixin.java
+++ b/src/main/java/net/id/paradiselost/mixin/block/CropBlockMixin.java
@@ -1,0 +1,22 @@
+package net.id.paradiselost.mixin.block;
+
+import net.id.paradiselost.blocks.ParadiseLostBlocks;
+import net.minecraft.block.BlockState;
+import net.minecraft.block.CropBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.BlockView;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+@Mixin(CropBlock.class)
+public class CropBlockMixin {
+    @Inject(
+            method = "canPlantOnTop",
+            at = @At("TAIL")
+    )
+    private void canPlantOnTop(BlockState floor, BlockView world, BlockPos pos, CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(cir.getReturnValue() || floor.isOf(ParadiseLostBlocks.FARMLAND));
+    }
+}

--- a/src/main/java/net/id/paradiselost/mixin/block/EnchantingTableBlockMixin.java
+++ b/src/main/java/net/id/paradiselost/mixin/block/EnchantingTableBlockMixin.java
@@ -1,0 +1,32 @@
+package net.id.paradiselost.mixin.block;
+
+import net.id.paradiselost.blocks.ParadiseLostBlocks;
+import net.minecraft.block.Blocks;
+import net.minecraft.block.EnchantingTableBlock;
+import net.minecraft.util.math.BlockPos;
+import net.minecraft.world.World;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfoReturnable;
+
+/**
+ * Allows the bookshelves tag to change enchantment level requirements.
+ *
+ * Credit: Taken from Gudenau's MoreTags
+ */
+@Mixin(EnchantingTableBlock.class)
+public abstract class EnchantingTableBlockMixin {
+    @Inject(
+            method = "canAccessBookshelf",
+            at = @At("TAIL"),
+            cancellable = true
+    )
+    private static void canAccessBookshelf(World world, BlockPos tablePos, BlockPos bookshelfOffset, CallbackInfoReturnable<Boolean> cir) {
+        cir.setReturnValue(
+                cir.getReturnValue() ||
+                        world.getBlockState(tablePos.add(bookshelfOffset)).isOf(ParadiseLostBlocks.SKYROOT_BOOKSHELF)
+                        && world.isAir(tablePos.add(bookshelfOffset.getX() / 2, bookshelfOffset.getY(), bookshelfOffset.getZ() / 2))
+        );
+    }
+}

--- a/src/main/resources/data/c/tags/blocks/bookshelves.json
+++ b/src/main/resources/data/c/tags/blocks/bookshelves.json
@@ -1,6 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "paradise_lost:skyroot_bookshelf"
-  ]
-}

--- a/src/main/resources/data/c/tags/blocks/farmland.json
+++ b/src/main/resources/data/c/tags/blocks/farmland.json
@@ -1,6 +1,0 @@
-{
-  "replace": false,
-  "values": [
-    "paradise_lost:farmland"
-  ]
-}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -34,7 +34,6 @@
     "fabric-registry-sync-v0": "*",
     "trinkets": "*",
     "gud_recipe_confidence": "*",
-    "moretags": ">=2.0.0",
     "satin": "*"
   },
   "mixins": [

--- a/src/main/resources/paradise_lost.mixins.json
+++ b/src/main/resources/paradise_lost.mixins.json
@@ -5,6 +5,8 @@
   "compatibilityLevel": "JAVA_17",
   "mixins": [
     "block.BlockMixin",
+    "block.CropBlockMixin",
+    "block.EnchantingTableBlockMixin",
     "block.FarmlandBlockMixin",
     "entity.CowEntityMixin",
     "entity.EntityMixin",


### PR DESCRIPTION
Removes MoreTags as a dependency, and implements the two mixins we need, with an appropriately fixed cropblock mixin that IS compatible with Farmer's Delight, or any other mods that add or mixin to farmland

Fixes: #726 and #623 

Because MoreTags is no longer included, The following are resolved:
#701, #664, #647, #601, and #598