### PR TITLE
Fix Mystery Milk giving no effects in Survival

### DIFF
--- a/src/main/java/net/id/paradiselost/items/food/MysteryMilkItem.java
+++ b/src/main/java/net/id/paradiselost/items/food/MysteryMilkItem.java
@@ -20,7 +20,7 @@ public class MysteryMilkItem extends Item {
 
     @Override
     public ItemStack finishUsing(ItemStack stack, World world, LivingEntity user) {
-        return user instanceof PlayerEntity player && player.getAbilities().creativeMode
-                ? super.finishUsing(stack, world, user) : new ItemStack(ParadiseLostItems.VIAL);
+        super.finishUsing(stack, world, user);
+        return stack.isEmpty() ? new ItemStack(ParadiseLostItems.VIAL) : stack;
     }
 }


### PR DESCRIPTION
Drinking Mystery Milk in survival mode does not call the `eatFood` handler. This pull request fixes that. Since the handler already decrements the item stack if the player is not in creative mode, the stack is only replaced if the resulting stack is empty.